### PR TITLE
Make references to .Site.Params lowercase for compatibility with Hugo 0.17

### DIFF
--- a/layouts/partials/core/css.html
+++ b/layouts/partials/core/css.html
@@ -4,7 +4,7 @@
 <!-- Load font awesome used for various icons -->
 <link rel="stylesheet" href="{{ .Site.BaseURL }}css/font-awesome.min.css">
 
-{{ with .Site.Params.Highlight }}
+{{ with .Site.Params.highlight }}
     <!-- Load highlight theme used for client-side syntax highlighting -->
     <link rel="stylesheet" href="{{ $.Site.BaseURL }}css/styles/{{ .style }}.css">
 {{ end }}

--- a/layouts/partials/core/js.html
+++ b/layouts/partials/core/js.html
@@ -10,7 +10,7 @@
 <!-- Load masonry used for layout on list pages -->
 <script src="{{ .Site.BaseURL }}js/masonry.pkgd.min.js"></script>
 
-{{ if .Site.Params.Highlight }}
+{{ if .Site.Params.highlight }}
     <!-- Load highlight used for client-side syntax highlighting -->
     <script src="{{ .Site.BaseURL }}js/highlight.pack.js"></script>
 {{ end }}

--- a/layouts/partials/core/main-menu.html
+++ b/layouts/partials/core/main-menu.html
@@ -36,7 +36,7 @@
             </ul>
         </li>
         <li><a href="#!" data-lightbox-id="searchbox"><i class="fa fa-search fa-2x"></i></a></li>
-        {{ with .Site.Params.Footer }}
+        {{ with .Site.Params.footer }}
             <li class="blue-grey-text" style="border-top: 1px solid;"><!-- Separator --></li>
             {{ range .List }}
                 <li>

--- a/layouts/partials/homepage/single.html
+++ b/layouts/partials/homepage/single.html
@@ -5,7 +5,7 @@
 {{ $baseUrl := .Site.BaseURL }}
 <body class="page-colors">
     <div class="parallax">
-        {{ with .Site.Params.Header }}
+        {{ with .Site.Params.header }}
             <!-- NOTE: Must be at root level for firefox to work (cannot wrap in header) -->
             <div class="parallax__group">
                 <div class="parallax__layer parallax__layer--base">
@@ -33,7 +33,7 @@
                 </div>
 
                 <div class="flex-container">
-                    {{ range .Site.Params.Cells.List }}
+                    {{ range .Site.Params.cells.list }}
                         <!-- 
                              Note: The link and contents must be here since we 
                              cannot pass .Site.BaseURL as part of the context 
@@ -78,7 +78,7 @@
                     {{ end }}
                 </div>
 
-                {{ with .Site.Params.Footer }}
+                {{ with .Site.Params.footer }}
                     <div class="row-colors right-align">
                         <ul class="main-page-footer horizontal no-bullets no-margin">
                             {{ range .List }}


### PR DESCRIPTION
Scenario: I'm trying to build a new site, using Hugo 0.17 and the grid-side theme at commit 8f162ae0c4f4097778ac9d7e7a873f8fb29269c5. The Params.Header section is present in the config.toml, but the home page renders without the background image, nor the user info box, as if Params.Header is not set.

The docs for Hugo say that "All Params are only accessible using all lowercase characters." After making the change in this commit, the home page renders as expected.

I'm a rank novice at both Hugo itself and the GridSide theme, so please review this pull request with all due diligence. Still trying to find out how I can convince Hugo to spit out a warning when referencing undefined data (and not holding my breath, because I think the behavior is intentional, as using the "with" clause implies the data may be absent in the first place, so this theme appears to have keeled over as a result of a semantics change in Hugo 0.17, which may or may not have been intentional).